### PR TITLE
Fix #14 - Add token refresh to spotify api class

### DIFF
--- a/src/data/spotifyDAO.ts
+++ b/src/data/spotifyDAO.ts
@@ -16,21 +16,26 @@ export class SpotifyDAO {
             clientSecret,
         });
 
-        // Retrieve an access token.
+        this.fetchAccessToken();
+    }
+
+    private async fetchAccessToken() {
         this.api.clientCredentialsGrant().then(
             (data) => {
                 console.log('Spotify access token expires in ' + data.body.expires_in);
                 console.log('Spotify access token is ' + data.body.access_token);
-                setTimeout(() => {
-                    console.log('Spotify access token expired!');
-                }, data.body.expires_in * 1000);
 
                 // Save the access token so that it's used in future calls
                 this.api.setAccessToken(data.body.access_token);
+
+                // Recursively refetch after the duration of 'expires_in' - 1m buffer period
+                setTimeout(() => {
+                    this.fetchAccessToken();
+                }, data.body.expires_in * 1000 - 60000);
             },
             (err) => {
-                console.log('Something went wrong when retrieving an access token', err);
-            },
+                console.log('Something went wrong when retrieving a spotify access token', err);
+            }
         );
     }
 

--- a/src/data/spotifyDAO.ts
+++ b/src/data/spotifyDAO.ts
@@ -31,7 +31,7 @@ export class SpotifyDAO {
                 // Recursively refetch after the duration of 'expires_in' - 1m buffer period
                 setTimeout(() => {
                     this.fetchAccessToken();
-                }, data.body.expires_in * 1000 - 60000);
+                }, (data.body.expires_in - 60) * 1000);
             },
             (err) => {
                 console.log('Something went wrong when retrieving a spotify access token', err);


### PR DESCRIPTION
I'm *fairly* certain that this doesn't have a memory leak. I believe the `setTimeout` schedules the callback and then returns, so the reference to the timer is garbage collected 🤔 